### PR TITLE
fix: Table discovery prefers derived classes over base (MRO-based)

### DIFF
--- a/src/genro_proxy/sql/sqldb.py
+++ b/src/genro_proxy/sql/sqldb.py
@@ -189,11 +189,19 @@ class SqlDb:
                 by_name[name] = table_class
             # else: existing is same or more derived, keep it
 
-        # Phase 3: Register the winning classes
+        # Phase 3: Register or replace with more derived classes
         registered: list[Table] = []
         for table_class in by_name.values():
-            if table_class.name not in self.tables:
+            name = table_class.name
+            existing = self.tables.get(name)
+            if existing is None:
+                # New table
                 registered.append(self.add_table(table_class))
+            elif table_class is not type(existing) and issubclass(table_class, type(existing)):
+                # New class is strictly more derived, replace existing
+                self.tables[name] = table_class(self)
+                registered.append(self.tables[name])
+            # else: existing is same or more derived, keep it
         return registered
 
     def table(self, name: str) -> Table:


### PR DESCRIPTION
## Summary
- Table discovery now collects all classes first, then uses MRO to keep only the most derived version
- Allows proxy services (e.g., genro-wopi) to extend base tables and have the extended version used automatically

## Test plan
- [x] All 627 genro-proxy tests pass
- [x] Verified from genro-wopi: `TenantsTable` now comes from `genro_wopi.entities.tenant.table`
- [x] `get_wopi_client_url` method is available on the discovered table

Ref #1